### PR TITLE
Upgrade to IdentityServer4 3.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,6 @@ ModelManifest.xml
 # CAKE
 tools/
 /sample/IdentityServer4.Postgresql.Sample/Logs
+
+/.idea
+tempkey.rsa

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ addons:
     packages:
     
 script: 
+    - curl https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version 3.0.100
+    - if test "$TRAVIS_OS_NAME" == "linux"; then export PATH="/home/travis/.dotnet":"$PATH"; fi
+    - if test "$TRAVIS_OS_NAME" == "osx"; then export PATH="/Users/travis/.dotnet":"$PATH"; fi
     - chmod +x build.sh
     #- ./build.sh
     - dotnet restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ install:
   - curl -L -O -S -s http://www.postgresonline.com/downloads/%PG_PLV8_EXTENSION_ZIP_FILENAME%.zip
   - 7z x %PG_PLV8_EXTENSION_ZIP_FILENAME%.zip
   - xcopy /s /y /d %PG_PLV8_EXTENSION_ZIP_FILENAME% "%POSTGRES_PATH%\"	
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "dotnet-install.ps1" 
+  - ps: .\dotnet-install.ps1 --Version 3.0.100
 build_script:
 #- createdb idsrv4_test
 #- psql -U postgres -c "create database idsrv4_test;"

--- a/sample/ConsoleClient/ConsoleClient.csproj
+++ b/sample/ConsoleClient/ConsoleClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>ConsoleClient</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ConsoleClient</PackageId>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="3.10.2" />
+    <PackageReference Include="IdentityModel" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/sample/ConsoleClient/Program.cs
+++ b/sample/ConsoleClient/Program.cs
@@ -1,14 +1,23 @@
 ﻿using IdentityModel.Client;
 using System;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace ConsoleClient
 {
     public class Program
     {
-        public static void Main(string[] args)
-        { 
-            var tokenClient = new TokenClient("http://localhost:5005/connect/token", "ro.client", "secret");
-            var tokenResponse = tokenClient.RequestClientCredentialsAsync("api1").GetAwaiter().GetResult();
+        public static async Task Main(string[] args)
+        {
+            var httpClient = new HttpClient();
+            var options = new TokenClientOptions
+            {
+                Address = "http://localhost:5000/connect/token",
+                ClientId = "ro.client",
+                ClientSecret = "secret"
+            };
+            var tokenClient = new TokenClient(httpClient, options);
+            var tokenResponse = await tokenClient.RequestClientCredentialsTokenAsync("api1");
             Console.WriteLine("Error : {0}", tokenResponse.Error);
             Console.WriteLine("Token : {0}", tokenResponse.AccessToken);
             Console.Read();

--- a/sample/ConsoleClient/Properties/AssemblyInfo.cs
+++ b/sample/ConsoleClient/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/sample/IdentityServer4.Postgresql.Sample/IdentityServer4.Postgresql.Sample.csproj
+++ b/sample/IdentityServer4.Postgresql.Sample/IdentityServer4.Postgresql.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>IdentityServer4.Postgresql.Sample</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -16,10 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\IdentityServer4.Postgresql\IdentityServer4.Postgresql.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6" />
   </ItemGroup>
 
 </Project>

--- a/sample/IdentityServer4.Postgresql.Sample/Program.cs
+++ b/sample/IdentityServer4.Postgresql.Sample/Program.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 
 namespace IdentityServer4.Postgresql.Sample
@@ -18,7 +13,6 @@ namespace IdentityServer4.Postgresql.Sample
 		public static IWebHost BuildWebHost(string[] args) =>
 			WebHost.CreateDefaultBuilder(args)
 				.UseStartup<Startup>()
-
 				.Build();
 	}
 }

--- a/sample/IdentityServer4.Postgresql.Sample/Startup.cs
+++ b/sample/IdentityServer4.Postgresql.Sample/Startup.cs
@@ -1,23 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using IdentityServer4.Postgresql.Extensions;
 using Marten;
 using IdentityServer4.Models;
 using IdentityServer4.Postgresql.Mappers;
 using IdentityServer4.Postgresql.Entities;
+using Microsoft.Extensions.Hosting;
 
 namespace IdentityServer4.Postgresql.Sample
 {
 	public class Startup
 	{
-		private const string connection = "host=localhost;database=sample;user id=postgres; Password=skhokho";
+		private const string connection = "host=localhost;database=sample;user id=postgres; Password=postgres";
 		// This method gets called by the runtime. Use this method to add services to the container.
 		// For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
 		public void ConfigureServices(IServiceCollection services)
@@ -26,7 +24,7 @@ namespace IdentityServer4.Postgresql.Sample
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 		{
 			InitData(app);
 
@@ -57,9 +55,9 @@ namespace IdentityServer4.Postgresql.Sample
 					session.StoreObjects(resources);
 				}
 
-				if (!session.Query<IdentityServer4.Postgresql.Entities.IdentityResource>().Any())
+				if (!session.Query<Entities.IdentityResource>().Any())
 				{
-					var resources = new List<IdentityServer4.Postgresql.Entities.IdentityResource> {
+					var resources = new List<Entities.IdentityResource> {
 						new IdentityResources.OpenId().ToEntity(),
 						new IdentityResources.Profile().ToEntity(),
 						new IdentityResources.Email().ToEntity(),
@@ -67,9 +65,9 @@ namespace IdentityServer4.Postgresql.Sample
 					};
 					session.StoreObjects(resources);
 				}
-				if (!session.Query<IdentityServer4.Postgresql.Entities.Client>().Any())
+				if (!session.Query<Entities.Client>().Any())
 				{
-					var clients = new List<IdentityServer4.Postgresql.Entities.Client>
+					var clients = new List<Entities.Client>
 					{
 						  new Entities.Client
 							{
@@ -77,19 +75,30 @@ namespace IdentityServer4.Postgresql.Sample
 								Id = "ro.client",
 								ClientId ="ro.client",
 								ClientName = "mvc",
-								AllowedGrantTypes =  new List<ClientGrantType> { new ClientGrantType { GrantType = GrantType.Hybrid } },
-								AllowedCorsOrigins =  new List<ClientCorsOrigin>  {new ClientCorsOrigin { Origin = "http://localhost:5003" } },
+								AllowedGrantTypes =  new List<ClientGrantType>
+								{
+									new ClientGrantType { GrantType = GrantType.ClientCredentials },
+									new ClientGrantType { GrantType = GrantType.Hybrid }
+								},
+								AllowedCorsOrigins =  new List<ClientCorsOrigin>
+								{
+									new ClientCorsOrigin { Origin = "http://localhost:5003" }
+								},
 								RequireClientSecret = true,
-								ClientSecrets = new List<ClientSecret> { new ClientSecret { Value = "secret".Sha256() }  },
+								ClientSecrets = new List<ClientSecret>
+								{
+									new ClientSecret { Value = "secret".Sha256() }
+								},
 								RequireConsent = false,
 								AllowedScopes = new List<ClientScope>{
-									 new ClientScope { Scope = IdentityServer4.IdentityServerConstants.StandardScopes.OpenId },
-									 new ClientScope { Scope = IdentityServer4.IdentityServerConstants.StandardScopes.Profile },
+									 new ClientScope { Scope = IdentityServerConstants.StandardScopes.OpenId },
+									 new ClientScope { Scope = IdentityServerConstants.StandardScopes.Profile },
 									 new ClientScope { Scope ="api1" }
 								},
-								RedirectUris = new List<ClientRedirectUri> { new ClientRedirectUri { RedirectUri ="http://localhost:5003/signin-oidc" }
+								RedirectUris = new List<ClientRedirectUri>
+								{
+									new ClientRedirectUri { RedirectUri ="http://localhost:5003/signin-oidc" }
 								}
-
 							}
 
 						};

--- a/src/IdentityServer4.Postgresql/Entities/ApiResourceClaim.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ApiResourceClaim.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 { 
     public class ApiResourceClaim : UserClaim
     {

--- a/src/IdentityServer4.Postgresql/Entities/ApiScope.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ApiScope.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace IdentityServer4.Postgresql.Entities
 {

--- a/src/IdentityServer4.Postgresql/Entities/ApiScopeClaim.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ApiScopeClaim.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ApiScopeClaim:UserClaim
     {

--- a/src/IdentityServer4.Postgresql/Entities/ApiSecret.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ApiSecret.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ApiSecret : Secret
     {

--- a/src/IdentityServer4.Postgresql/Entities/ClientClaim.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientClaim.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace IdentityServer4.Postgresql.Entities
 {
@@ -9,5 +6,6 @@ namespace IdentityServer4.Postgresql.Entities
     {
         public string Type { get; set; }
         public string Value { get; set; }
+        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
     }
 }

--- a/src/IdentityServer4.Postgresql/Entities/ClientCorsOrigin.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientCorsOrigin.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ClientCorsOrigin
     {

--- a/src/IdentityServer4.Postgresql/Entities/ClientGrantType.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientGrantType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ClientGrantType
     {

--- a/src/IdentityServer4.Postgresql/Entities/ClientIdPRestriction.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientIdPRestriction.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ClientIdPRestriction
     {

--- a/src/IdentityServer4.Postgresql/Entities/ClientPostLogoutRedirectUri.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientPostLogoutRedirectUri.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ClientPostLogoutRedirectUri
     {

--- a/src/IdentityServer4.Postgresql/Entities/ClientRedirectUri.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientRedirectUri.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ClientRedirectUri
     {

--- a/src/IdentityServer4.Postgresql/Entities/ClientScope.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientScope.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ClientScope
     {

--- a/src/IdentityServer4.Postgresql/Entities/ClientSecret.cs
+++ b/src/IdentityServer4.Postgresql/Entities/ClientSecret.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class ClientSecret : Secret
     {

--- a/src/IdentityServer4.Postgresql/Entities/EntityKey.cs
+++ b/src/IdentityServer4.Postgresql/Entities/EntityKey.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public abstract class EntityKey
     {

--- a/src/IdentityServer4.Postgresql/Entities/IdentityClaim.cs
+++ b/src/IdentityServer4.Postgresql/Entities/IdentityClaim.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public class IdentityClaim: UserClaim
     {

--- a/src/IdentityServer4.Postgresql/Entities/IdentityResource.cs
+++ b/src/IdentityServer4.Postgresql/Entities/IdentityResource.cs
@@ -1,5 +1,4 @@
-﻿using Marten.Schema;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace IdentityServer4.Postgresql.Entities

--- a/src/IdentityServer4.Postgresql/Entities/PersistedGrant.cs
+++ b/src/IdentityServer4.Postgresql/Entities/PersistedGrant.cs
@@ -1,5 +1,4 @@
-﻿using Marten.Schema;
-using System;
+﻿using System;
 
 namespace IdentityServer4.Postgresql.Entities
 {

--- a/src/IdentityServer4.Postgresql/Entities/Secret.cs
+++ b/src/IdentityServer4.Postgresql/Entities/Secret.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using static IdentityServer4.IdentityServerConstants;
 
 namespace IdentityServer4.Postgresql.Entities

--- a/src/IdentityServer4.Postgresql/Entities/UserClaim.cs
+++ b/src/IdentityServer4.Postgresql/Entities/UserClaim.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IdentityServer4.Postgresql.Entities
+﻿namespace IdentityServer4.Postgresql.Entities
 {
     public abstract class UserClaim
     {

--- a/src/IdentityServer4.Postgresql/Extensions/IdentityServerBuilderExtensions.cs
+++ b/src/IdentityServer4.Postgresql/Extensions/IdentityServerBuilderExtensions.cs
@@ -5,9 +5,9 @@ using IdentityServer4.Services;
 using IdentityServer4.Stores;
 using Marten;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using Microsoft.Extensions.Hosting;
 
 namespace IdentityServer4.Postgresql.Extensions
 {
@@ -79,7 +79,7 @@ namespace IdentityServer4.Postgresql.Extensions
             builder.Services.AddSingleton<TokenCleanup>();
             return builder;
         }
-        public static IApplicationBuilder UseIdentityServerTokenCleanup(this IApplicationBuilder app, IApplicationLifetime applicationLifetime)
+        public static IApplicationBuilder UseIdentityServerTokenCleanup(this IApplicationBuilder app, IHostApplicationLifetime applicationLifetime)
         {
             var tokenCleanup = app.ApplicationServices.GetService<TokenCleanup>();
             if (tokenCleanup == null)

--- a/src/IdentityServer4.Postgresql/IdentityServer4.Postgresql.csproj
+++ b/src/IdentityServer4.Postgresql/IdentityServer4.Postgresql.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Marten persistence layer for IdentityServer4 using postgresql as a document store</Description>
     <VersionPrefix></VersionPrefix>
-    <Version>2.0.5</Version>
+    <Version>3.0.0</Version>
     <Authors>Sifiso Shezi</Authors>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>IdentityServer4.Postgresql</AssemblyName>
     <PackageId>IdentityServer4.Postgresql</PackageId>
     <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer;Postgresql</PackageTags>
@@ -15,8 +15,8 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="2.3.0" />
-    <PackageReference Include="Marten" Version="3.1.0" />
+    <PackageReference Include="IdentityServer4" Version="3.0.1" />
+    <PackageReference Include="Marten" Version="3.8.0" />
     <PackageReference Include="AutoMapper" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/IdentityServer4.Postgresql/Mappers/ClientMapperProfile.cs
+++ b/src/IdentityServer4.Postgresql/Mappers/ClientMapperProfile.cs
@@ -1,9 +1,6 @@
 ﻿using AutoMapper;
 using IdentityServer4.Postgresql.Entities;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace IdentityServer4.Postgresql.Mappers
 {

--- a/src/IdentityServer4.Postgresql/Mappers/IdentityResourceMapperProfile.cs
+++ b/src/IdentityServer4.Postgresql/Mappers/IdentityResourceMapperProfile.cs
@@ -1,9 +1,6 @@
 ﻿using AutoMapper;
 using IdentityServer4.Postgresql.Entities;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace IdentityServer4.Postgresql.Mappers
 {

--- a/src/IdentityServer4.Postgresql/Properties/AssemblyInfo.cs
+++ b/src/IdentityServer4.Postgresql/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/IdentityServer4.Postgresql/Services/CorsPolicyService.cs
+++ b/src/IdentityServer4.Postgresql/Services/CorsPolicyService.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using IdentityServer4.Postgresql.Entities;
 using System.Linq;
 using System.Threading.Tasks;
-using System;
 
 namespace IdentityServer4.Postgresql.Services
 {

--- a/src/IdentityServer4.Postgresql/Stores/PersistedGrantStore.cs
+++ b/src/IdentityServer4.Postgresql/Stores/PersistedGrantStore.cs
@@ -1,12 +1,13 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using IdentityServer4.Postgresql.Mappers;
 using Marten;
+
 namespace IdentityServer4.Postgresql.Stores
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using IdentityServer4.Models;
-    using IdentityServer4.Stores;
-    using IdentityServer4.Postgresql.Mappers;
 
     public class PersistedGrantStore : IPersistedGrantStore
     {
@@ -24,7 +25,7 @@ namespace IdentityServer4.Postgresql.Stores
 
         public async Task<PersistedGrant> GetAsync(string key)
         {
-            var grant =  await _documentSession.Query<Entities.PersistedGrant>().FirstOrDefaultAsync(x => x.Key == key).ConfigureAwait(false);
+            var grant = await _documentSession.Query<Entities.PersistedGrant>().FirstOrDefaultAsync(x => x.Key == key).ConfigureAwait(false);
             return grant?.ToModel();
         }
 

--- a/src/IdentityServer4.Postgresql/TokenCleanup.cs
+++ b/src/IdentityServer4.Postgresql/TokenCleanup.cs
@@ -4,8 +4,6 @@ using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/test/IdentityServer4.Postgresql.IntegrationTests/DatabaseFixture.cs
+++ b/test/IdentityServer4.Postgresql.IntegrationTests/DatabaseFixture.cs
@@ -12,7 +12,7 @@ namespace IdentityServer4.Postgresql.IntegrationTests
             
 			this.Store = DocumentStore.For(c => 
             {
-                c.Connection($"User ID={GetEnv("PG_USER","sa")};Password={GetEnv("PG_PASSWORD","skhokho")};Host={GetEnv("PG_HOST","localhost")};Port={GetEnv("PG_PORT","5432")};Database={GetEnv("PG_DATABASE","idsrv4_test")};");
+                c.Connection($"User ID={GetEnv("PG_USER","postgres")};Password={GetEnv("PG_PASSWORD","postgres")};Host={GetEnv("PG_HOST","localhost")};Port={GetEnv("PG_PORT","5432")};Database={GetEnv("PG_DATABASE","idsrv4_test")};");
                 c.PLV8Enabled = false;
                 
             });

--- a/test/IdentityServer4.Postgresql.IntegrationTests/IdentityServer4.Postgresql.IntegrationTests.csproj
+++ b/test/IdentityServer4.Postgresql.IntegrationTests/IdentityServer4.Postgresql.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>IdentityServer4.Postgresql.IntegrationTests</AssemblyName>
     <PackageId>IdentityServer4.Postgresql.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IdentityServer4.Postgresql.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/test/IdentityServer4.Postgresql.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/test/IdentityServer4.Postgresql.IntegrationTests/Stores/ClientStoreTests.cs
+++ b/test/IdentityServer4.Postgresql.IntegrationTests/Stores/ClientStoreTests.cs
@@ -1,11 +1,7 @@
 ﻿using IdentityServer4.Postgresql.Entities;
 using IdentityServer4.Postgresql.Stores;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using IdentityServer4.Postgresql.Mappers;
 using Xunit;
-using GenFu;
 
 namespace IdentityServer4.Postgresql.IntegrationTests.Stores
 {

--- a/test/IdentityServer4.Postgresql.IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/test/IdentityServer4.Postgresql.IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using IdentityServer4.Postgresql.Mappers;
 using Xunit;
-using GenFu;
 using IdentityServer4.Postgresql.Entities;
 using IdentityServer4.Postgresql.Stores;
 

--- a/test/IdentityServer4.Postgresql.IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/test/IdentityServer4.Postgresql.IntegrationTests/Stores/ResourceStoreTests.cs
@@ -1,8 +1,6 @@
 ﻿using GenFu;
 using IdentityServer4.Postgresql.Entities;
 using IdentityServer4.Postgresql.Stores;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;

--- a/test/IdentityServer4.Postgresql.UnitTests/IdentityServer4.Postgresql.UnitTests.csproj
+++ b/test/IdentityServer4.Postgresql.UnitTests/IdentityServer4.Postgresql.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>IdentityServer4.Postgresql.UnitTests</AssemblyName>
     <PackageId>IdentityServer4.Postgresql.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/IdentityServer4.Postgresql.UnitTests/Properties/AssemblyInfo.cs
+++ b/test/IdentityServer4.Postgresql.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following


### PR DESCRIPTION
As it's now .NET Core 3 time and I see that your fork is most up-to-date, I'm offering here update for the libs and small tweaks.

* IdentityServer4 3.0.1
* Upgrade lib version to 3.0.0 to indicate major change
* Tweaks to tests to make them pass
* Use default postgres/postgres login which is more predictable
* Tweak queries a bit to reduce in-memory operations
* Fix sample to work with new lib